### PR TITLE
Ignore missing associated files with warning

### DIFF
--- a/src/Render/Program.cs
+++ b/src/Render/Program.cs
@@ -91,7 +91,13 @@ namespace D2L.Dev.Docs.Render {
 		private static void CopyFileKeepingRelativePath( string filepath, string outputDirectoryRoot ) {
 			string outputPath = Path.Combine( outputDirectoryRoot, filepath );
 			string parent = Directory.GetParent( outputPath ).FullName;
-			
+
+			if ( !File.Exists( filepath ) ) {
+				Console.WriteLine("WARNING: file '{0}' not found", filepath);
+				return;
+			}
+
+			// TODO: Handle copying directories
 			if ( File.Exists( outputPath ) ) {
 				return;
 			}


### PR DESCRIPTION
This was causing an issue [here](https://github.com/Brightspace/d2l.dev/pull/395/checks?check_run_id=555768599).

This can be reverted once we figure out a good way to do #12 