### PR TITLE
Added input & output to context, less GetEnvironmentVariable calls

### DIFF
--- a/src/Render/Markdown/DocumentContext.cs
+++ b/src/Render/Markdown/DocumentContext.cs
@@ -3,9 +3,13 @@
 	// Some possibilities could be github repo url, list of docs repos
 	internal sealed class DocumentContext {
 
+		public string InputDirectory { get; }
+		public string OutputDirectory { get; }
 		public string DocRootRepoName { get; }
 
-		public DocumentContext( string docRootRepoName ) {
+		public DocumentContext( string inputDir, string outputDir, string docRootRepoName ) {
+			InputDirectory = inputDir;
+			OutputDirectory = outputDir;
 			DocRootRepoName = docRootRepoName;
 		}
 	}

--- a/src/Render/Program.cs
+++ b/src/Render/Program.cs
@@ -25,15 +25,18 @@ namespace D2L.Dev.Docs.Render {
 				Directory.CreateDirectory( output );
 			}
 
+			// See https://help.github.com/en/actions/configuring-and-managing-workflows/using-environment-variables#default-environment-variables
+			var repoName = Environment.GetEnvironmentVariable( "GITHUB_REPOSITORY" ).Split( '/' )[1];
+			var context = new DocumentContext( input, output, repoName );
 			var directories = Directory.EnumerateFiles( input, "*", SearchOption.AllDirectories );
 			foreach ( var filename in directories ) {
-				await DoFile( new RelativeFile( input, output, filename ) );
+				await DoFile( context, new RelativeFile( input, output, filename ) );
 			}
 
 			return 0;
 		}
 
-		private static async Task DoFile( RelativeFile file ) {
+		private static async Task DoFile( DocumentContext context, RelativeFile file ) {
 			if ( file.Extension != "md" ) {
 				return;
 			}
@@ -46,10 +49,6 @@ namespace D2L.Dev.Docs.Render {
 
 			var text = await file.Read();
 
-			// See https://help.github.com/en/actions/configuring-and-managing-workflows/using-environment-variables#default-environment-variables
-			var repoName = Environment.GetEnvironmentVariable( "GITHUB_REPOSITORY" ).Split('/')[1];
-
-			var context = new DocumentContext( repoName );
 			var doc = MarkdownFactory.Parse( text );
 			doc.ApplyD2LTweaks();
 			var html = MarkdownFactory.RenderToString( doc, context );


### PR DESCRIPTION
I plan to use this in RelativeFile later, and I think having input & output directories here will work nicely with the planned VFS.