### PR TITLE
Use Markdig table renderer

### DIFF
--- a/src/Render/Markdown/MarkdownFactory.cs
+++ b/src/Render/Markdown/MarkdownFactory.cs
@@ -1,6 +1,7 @@
 using System.IO;
 using Markdig;
 using Markdig.Extensions.AutoIdentifiers;
+using Markdig.Extensions.Tables;
 using Markdig.Parsers;
 using Markdig.Renderers;
 using Markdig.Renderers.Html;
@@ -55,6 +56,8 @@ namespace D2L.Dev.Docs.Render.Markdown {
 			renderer.ObjectRenderers.Replace<HeadingRenderer>(
 				new HeadingLinkRenderer()
 			);
+
+			renderer.ObjectRenderers.Add( new HtmlTableRenderer() );
 
 			renderer.ObjectRenderers
 				.Find<CodeBlockRenderer>()


### PR DESCRIPTION
It seems like this wasn't automatically used, and tables weren't being rendered.

Will write a d2l-table renderer in a future PR, this is temporary.