### PR TITLE
Fix the edit button for repos other than architecture

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -5,4 +5,4 @@ if [ $# -ne 2 ]; then
 	exit 1
 fi
 
-dotnet run --launch-profile GitHubAction -p /render/src/Render/D2L.Dev.Docs.Render.csproj --input $1 --output $2
+dotnet run --no-launch-profile -p /render/src/Render/D2L.Dev.Docs.Render.csproj --input $1 --output $2

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -5,4 +5,4 @@ if [ $# -ne 2 ]; then
 	exit 1
 fi
 
-dotnet run -p /render/src/Render/D2L.Dev.Docs.Render.csproj --input $1 --output $2
+dotnet run --launch-profile GitHubAction -p /render/src/Render/D2L.Dev.Docs.Render.csproj --input $1 --output $2

--- a/src/Render/Properties/launchSettings.json
+++ b/src/Render/Properties/launchSettings.json
@@ -4,8 +4,11 @@
       "commandName": "Project",
       "commandLineArgs": "--input ..\\..\\..\\..\\..\\testdata\\input --output ..\\..\\..\\..\\..\\testdata\\output",
       "environmentVariables": {
-        "GITHUB_REPOSITORY": "Brightspace/architecture"
+        "GITHUB_REPOSITORY": "Brightspace/testero"
       }
+    },
+    "GitHubAction": {
+      "commandName": "Project"
     }
   }
 }

--- a/src/Render/Properties/launchSettings.json
+++ b/src/Render/Properties/launchSettings.json
@@ -6,9 +6,6 @@
       "environmentVariables": {
         "GITHUB_REPOSITORY": "Brightspace/testero"
       }
-    },
-    "GitHubAction": {
-      "commandName": "Project"
     }
   }
 }


### PR DESCRIPTION
I added some default runtime info for debugging. This got unintentionally used in the actual GitHub Action. This broke the edit button for any repo that didn't happen to match the default runtime, meaning I broke everything but the architecture repo.

This change creates a new launch profile that we use for the actual GitHub Action, allowing us to keep the easy debugging info.

I've changed the default info to reference a non-existent repo. This prevents the "one repo works" problem, making it easier to identify when things are broken.