### PR TITLE
Add support for branches other than master

### DIFF
--- a/src/Render/Markdown/DocumentContext.cs
+++ b/src/Render/Markdown/DocumentContext.cs
@@ -8,12 +8,13 @@ namespace D2L.Dev.Docs.Render.Markdown {
 		public string InputDirectory { get; }
 		public string OutputDirectory { get; }
 		public string DocRootRepoName { get; }
-		public SubModule SubModule { get; }
+		public string Branch { get; }
 
-		public DocumentContext( string inputDir, string outputDir, string docRootRepoName ) {
+		public DocumentContext( string inputDir, string outputDir, string docRootRepoName, string defaultBranch ) {
 			InputDirectory = inputDir;
 			OutputDirectory = outputDir;
 			DocRootRepoName = docRootRepoName;
+			Branch = defaultBranch;
 		}
 	}
 }

--- a/src/Render/Properties/launchSettings.json
+++ b/src/Render/Properties/launchSettings.json
@@ -4,7 +4,8 @@
       "commandName": "Project",
       "commandLineArgs": "--input ..\\..\\..\\..\\..\\testdata\\input --output ..\\..\\..\\..\\..\\testdata\\output",
       "environmentVariables": {
-        "GITHUB_REPOSITORY": "Brightspace/testero"
+        "GITHUB_REPOSITORY": "Brightspace/testero",
+        "GITHUB_REF": "refs/heads/cpacey/test"
       }
     }
   }


### PR DESCRIPTION
The goal is to support non-master default branches, such as "main". It turned out to be easier to have the output use the current branch - the current branch is provided by GitHub Actions, whereas the default branch requires making API calls.