### PR TITLE
Fix action with global.json

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -5,4 +5,6 @@ if [ $# -ne 2 ]; then
 	exit 1
 fi
 
-dotnet run --no-launch-profile -p /render/src/Render/D2L.Dev.Docs.Render.csproj --input $1 --output $2
+cd /render/src/Render
+
+dotnet run --no-launch-profile -p D2L.Dev.Docs.Render.csproj --input /github/workspace/$1 --output /github/workspace/$2


### PR DESCRIPTION
Previously, if the repo using the action had a global.json at the root, then he action's 'dotnet run' would use that. This would fail unless the global.json happened to specify the same sdk version as the docker image we're using.

With this change, we avoid this problem by explicitly running the action in the src/Render directory.