### PR TITLE
Fix "edit" button when docsPath is not root

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -7,4 +7,4 @@ fi
 
 cd /render/src/Render
 
-dotnet run --no-launch-profile -p D2L.Dev.Docs.Render.csproj --input /github/workspace/$1 --output /github/workspace/$2
+dotnet run --no-launch-profile -p D2L.Dev.Docs.Render.csproj --repo-root /github/workspace/ --docs-path $1 --output /github/workspace/$2

--- a/src/Render/Markdown/DocumentContext.cs
+++ b/src/Render/Markdown/DocumentContext.cs
@@ -9,12 +9,14 @@ namespace D2L.Dev.Docs.Render.Markdown {
 		public string OutputDirectory { get; }
 		public string DocRootRepoName { get; }
 		public string Branch { get; }
+		public string DocsPath { get; }
 
-		public DocumentContext( string inputDir, string outputDir, string docRootRepoName, string defaultBranch ) {
+		public DocumentContext( string inputDir, string outputDir, string docRootRepoName, string defaultBranch, string docsPath ) {
 			InputDirectory = inputDir;
 			OutputDirectory = outputDir;
 			DocRootRepoName = docRootRepoName;
 			Branch = defaultBranch;
+			DocsPath = docsPath;
 		}
 	}
 }

--- a/src/Render/Properties/launchSettings.json
+++ b/src/Render/Properties/launchSettings.json
@@ -2,7 +2,7 @@
   "profiles": {
     "D2L.Dev.Docs.Render": {
       "commandName": "Project",
-      "commandLineArgs": "--input ..\\..\\..\\..\\..\\testdata\\input --output ..\\..\\..\\..\\..\\testdata\\output",
+      "commandLineArgs": "--repo-root ..\\..\\..\\..\\..\\ --output ..\\..\\..\\..\\..\\testdata\\output --docs-path testdata\\input",
       "environmentVariables": {
         "GITHUB_REPOSITORY": "Brightspace/testero",
         "GITHUB_REF": "refs/heads/cpacey/test"


### PR DESCRIPTION
Previously, the edit button was always relative to the input folder. When the input folder was not the repo root, this would result in the edit link going to the wrong place in GitHub. Sometimes this would 404 and sometimes this would open the wrong file for edit (e.g. README.md at docsRoot and repo root).

With this change, the code is aware of both the repo root and the path within the repo. We can then use this to create the correct edit link.