### PR TITLE
Fix crash when template is null

### DIFF
--- a/src/Render/Markdown/DocumentContext.cs
+++ b/src/Render/Markdown/DocumentContext.cs
@@ -10,13 +10,17 @@ namespace D2L.Dev.Docs.Render.Markdown {
 		public string DocRootRepoName { get; }
 		public string Branch { get; }
 		public string DocsPath { get; }
+		public string RepoRoot { get; }
+		public string? TemplatePath { get; }
 
-		public DocumentContext( string inputDir, string outputDir, string docRootRepoName, string defaultBranch, string docsPath ) {
+		public DocumentContext( string inputDir, string outputDir, string docRootRepoName, string defaultBranch, string docsPath, string repoRoot, string? templatePath ) {
 			InputDirectory = inputDir;
 			OutputDirectory = outputDir;
 			DocRootRepoName = docRootRepoName;
 			Branch = defaultBranch;
 			DocsPath = docsPath;
+			RepoRoot = repoRoot;
+			TemplatePath = templatePath;
 		}
 	}
 }


### PR DESCRIPTION
Previously, we would check for a null template when deciding which template to use, but[ not before doing a `Path.Join` with the null input](https://github.com/Brightspace/render-docs-action/blob/4bed1bd5f62851710407bea9191242b4a929968a/src/Render/Program.cs#L46). With this change, we defer all use of the template input to when we're deciding which template to use.

I don't love that `Context` is basically a God Object, but this is a small step that gets a job done.